### PR TITLE
Add a jitter in noise variance to avoid posdef errors

### DIFF
--- a/c4_set_parameters.m
+++ b/c4_set_parameters.m
@@ -54,15 +54,16 @@ min_num_pixels = 400;                         % minimum number of non-masked pix
 % normalization parameters
 % I use 1216 is basically because I want integer in my saved filenames%
 %normalization_min_lambda = 1216 - 40;              % range of rest wavelengths to use   Å
-normalization_min_lambda = 1550 - 40; 
+normalization_min_lambda = 1600 - 40; 
 %normalization_max_lambda = 1216 + 40;              %   for flux normalization
-normalization_max_lambda = 1550 + 40; 
+normalization_max_lambda = 1600 + 40; 
 % null model parameters
 min_lambda         =  1256;                    % range of rest wavelengths to       Å
-max_lambda         = 3000;                    %   model
+max_lambda         =  1600;                    %   model
 dlambda            = 0.25;                    % separation of wavelength grid      Å
 k                  = 20;                      % rank of non-diagonal contribution
 max_noise_variance = 4^2;                     % maximum pixel noise allowed during model training
+jitter = 1e-6;                                % a small value to avoid noise variance V has zeros
 
 % optimization parameters
 minFunc_options =               ...           % optimization options for model fitting

--- a/learn_qso_model.m
+++ b/learn_qso_model.m
@@ -134,7 +134,7 @@ for i = 1:num_quasars
 
   pca_centered_rest_flux(i, ind) = nanmedian(this_pca_centered_rest_flux);
   
-  % assign meidans to the zeros in the noise_variances
+  % assign a jitter to those zeros in the noise_variances
   ind = rest_noise_variances(i, :) == 0;
   rest_noise_variances(i, ind) = jitter; % brutally assign a jitter value
 end

--- a/learn_qso_model.m
+++ b/learn_qso_model.m
@@ -25,7 +25,7 @@ all_noise_variance =       preqsos.all_noise_variance;
 all_noise_variance = all_noise_variance(train_ind, :);
 all_pixel_mask     =           preqsos.all_pixel_mask;
 all_pixel_mask     =     all_pixel_mask(train_ind, :);
-z_qsos             =        catalog.z_qsos(train_ind);
+z_qsos             =        catalog.all_zqso(train_ind);
 clear preqsos
 
 num_quasars = numel(z_qsos);
@@ -133,6 +133,10 @@ for i = 1:num_quasars
   ind = isnan(this_pca_centered_rest_flux);
 
   pca_centered_rest_flux(i, ind) = nanmedian(this_pca_centered_rest_flux);
+  
+  % assign meidans to the zeros in the noise_variances
+  ind = rest_noise_variances(i, :) == 0;
+  rest_noise_variances(i, ind) = jitter; % brutally assign a jitter value
 end
 
 % get top-k PCA vectors to initialize M


### PR DESCRIPTION
I ran `train_ind = '(catalog.filter_flags == 0)';`

- [ ] Does `jitter = 1e-6` make sense?

1. DR7 spectra have zeros in noise variance, which would cause invalid in GP log-likelihood. Specifically, the `chol` will return a positive definite error. I added a jitter = 1e-6 to avoid that happened. This value is borrowed from `emukit`: https://github.com/amzn/emukit/blob/master/emukit/model_wrappers/simple_gp_model.py#L66

2. The training data in DR7 is sparser than DR9, that caused that we couldn't train the redend very well. So I shrink the max_lambda from 3000A to 1600A.

3. See the attached. there are still many invalid pixels within covariance matrix. I suggest increasing the `dlambda` (pixel binning) to be larger https://github.com/rezamonadi/gp_C4/blob/master/c4_set_parameters.m#L63 

4. Normalization range could be outside of the modelling range. Now you can see the artefact of normalization in the covariance.

![mu](https://user-images.githubusercontent.com/23435784/88744981-b7f7e000-d0fd-11ea-98d7-bc29fca9f287.png)
![correlation_mat](https://user-images.githubusercontent.com/23435784/88744985-bc23fd80-d0fd-11ea-92bf-3ea1637987ac.png)
